### PR TITLE
feat(build): pass hardware target as argument to make

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,9 @@ jobs:
       - name: Cppcheck
         run: |
           cppcheck --version
-          TOOLS_OPEN_OCD_DIR_PATH=/usr/share/openocd/scripts make cppcheck
+          TOOLS_OPEN_OCD_DIR_PATH=/usr/share/openocd/scripts make cppcheck HW=ROBOTIC_ARM
+          TOOLS_OPEN_OCD_DIR_PATH=/usr/share/openocd/scripts make cppcheck HW=ARM_SLEEVE 
+
 
       - name: Clean build
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,4 +48,5 @@ jobs:
 
       - name: Build
         run: |
-          TOOLS_OPEN_OCD_DIR_PATH=/usr/share/openocd/scripts make
+          TOOLS_OPEN_OCD_DIR_PATH=/usr/share/openocd/scripts make HW=ROBOTIC_ARM
+          TOOLS_OPEN_OCD_DIR_PATH=/usr/share/openocd/scripts make HW=ARM_SLEEVE 

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,8 @@ else ifeq ($(HW), ARM_SLEEVE)
 TARGET_NAME = arm_sleeve
 STM_VERSION = STM32F411xE
 else ifeq ($(MAKECMDGOALS), clean)
-else ifeq ($(MAKECMDGOALS), cppcheck)
 else ifeq ($(MAKECMDGOALS), format)
-# HW argument not required for clean, cppcheck, format
+# HW argument not required for clean, format
 else
 $(error "Must pass HW=ROBOTIC_ARM or HW=ARM_SLEEVE")
 endif

--- a/src/drivers/io.h
+++ b/src/drivers/io.h
@@ -3,10 +3,6 @@
 
 #include <stdbool.h>
 
-// TODO: Improve multiple HW handling
-// #define ARM_SLEEVE
-#define ROBOTIC_ARM
-
 typedef enum {
     // ---- Port A ----
     IO_PA0, // PA0: A0, ADC1_IN0, TIM2_CH1, TIM5_CH1


### PR DESCRIPTION
I hard code define to select between hardware targets (STM32F446RE and STM32F411) since each has different pinouts for programming. This handling is done in the Makefile using defines at compile time.

Build for robotic arm: make HW=ROBOTIC_ARM
Build for arm sleeve: make HW=ARM_SLEEVE