### PR TITLE
feat(assert): add assert feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ SOURCES_WITH_HEADERS = \
 		  src/drivers/led.c \
 		  src/drivers/io.c \
 		  src/drivers/mcu_init.c \
+		  src/common/assert_handler.c \
 
 SOURCES = \
 		  src/main.c \
@@ -122,7 +123,8 @@ cppcheck:
 		-I $(INCLUDE_DIRS) \
 		-I $(ARMGCC_INCLUDE_DIR) \
 		$(addprefix -I, $(ARMGCC_STANDARD_LIB_INCLUDE_DIRS)) \
-		$(SOURCES)
+		$(SOURCES) \
+		$(DEFINES)
 
 format:
 	@$(FORMAT) -i $(SOURCES) $(HEADERS)

--- a/src/common/assert_handler.c
+++ b/src/common/assert_handler.c
@@ -1,0 +1,43 @@
+#include "assert_handler.h"
+#include "defines.h"
+#include <stm32f4xx.h>
+
+/* STM32 provides BKPT as an instruction to add breakpoints. The CPU will halt and the debugger will
+ * catch the breakpoint in GDB/VSCode. */
+#define BREAKPOINT __asm volatile("BKPT #0");
+
+/* Use correct test led ports and pins */
+#if defined(ROBOTIC_ARM)
+#define TEST_LED_PORT GPIOA
+#define TEST_LED_PIN 5
+#elif defined(ARM_SLEEVE)
+#define TEST_LED_PORT GPIOC
+#define TEST_LED_PIN 13
+#else
+#error "Board type not defined"
+#endif
+
+void assert_handler(void)
+{
+    // TODO: Turn off motors / servos ("safe state")
+    // TODO: Trace to console
+
+    /* STM32 makes breakpoints stop all running code because the code is run in debugger mode. As a
+    result, only use BREAKPOINT when tracing back code. Otherwise, leave this commented out since
+    the LED won't be able to blink with this line before it. */
+
+    // BREAKPOINT
+
+    // Configure pin as output
+    TEST_LED_PORT->MODER &= ~(0x3u << (TEST_LED_PIN * 2)); // Clear mode bits
+    TEST_LED_PORT->MODER |= (0x1u << (TEST_LED_PIN * 2)); // Set as output (binary 01)
+    TEST_LED_PORT->PUPDR &= ~(0x3u << (TEST_LED_PIN * 2)); // No pull-up/pull-down
+    TEST_LED_PORT->PUPDR |=
+        (0x0u << (TEST_LED_PIN * 2)); // (Optional, explicitly sets to 00: no pull)
+    TEST_LED_PORT->ODR &= ~(0x1u << TEST_LED_PIN); // Set output low
+
+    while (1) {
+        TEST_LED_PORT->ODR ^= (0x1u << TEST_LED_PIN); // Blink indefinitely
+        BUSY_WAIT_ms(250); // Delay
+    };
+}

--- a/src/common/assert_handler.h
+++ b/src/common/assert_handler.h
@@ -1,0 +1,14 @@
+#ifndef ASSERT_HANDLER_H
+
+// Assert implementation suitable for a microcontroller
+
+#define ASSERT(expression)                                                                         \
+    do {                                                                                           \
+        if (!(expression)) {                                                                       \
+            assert_handler();                                                                      \
+        }                                                                                          \
+    } while (0)
+
+void assert_handler(void);
+
+#endif // ASSERT_HANDLER_H

--- a/src/common/defines.h
+++ b/src/common/defines.h
@@ -1,12 +1,25 @@
 #ifndef DEFINES_H
 #define DEFINES_H
 
+#include <stdint.h>
+
+// In defines.h
+#ifdef ROBOTIC_ARM
+#define SYSTEM_CORE_CLOCK 180000000u
+#elif defined(ARM_SLEEVE)
+#define SYSTEM_CORE_CLOCK 100000000u
+#else
+#define SYSTEM_CORE_CLOCK 16000000u
+#endif
+
 #define UNUSED(x) (void)(x)
 #define SUPPRESS_UNUSED __attribute__((unused))
 #define ARRAY_SIZE(array) (sizeof(array) / sizeof(array[0]))
-
-#define CYCLES_1MHZ (1000000u)
-#define ms_TO_CYCLES(ms) ((CYCLES_1MHZ / 1000u) * ms)
-#define BUSY_WAIT_ms(ms) (__delay_cycles(ms_TO_CYCLES(ms)))
+#define BUSY_WAIT_ms(ms)                                                                           \
+    do {                                                                                           \
+        volatile uint32_t _n = (SYSTEM_CORE_CLOCK / 100000) * (ms);                                \
+        while (_n--)                                                                               \
+            __NOP();                                                                               \
+    } while (0)
 
 #endif // DEFINES_H

--- a/src/drivers/io.c
+++ b/src/drivers/io.c
@@ -1,7 +1,9 @@
 #include "io.h"
 #include "../common/defines.h"
+#include "../common/assert_handler.h"
 #include <stm32f4xx.h>
 #include <stdint.h>
+#include <stdbool.h>
 
 /* Extracing pin and port using bitwise operations. STM32 uses 16 pins per port
  * Enum value can be seen as:
@@ -57,67 +59,69 @@ static GPIO_TypeDef *const gpio_ports[] = { GPIOA, GPIOB, GPIOC, GPIOD };
 static const struct io_config io_initial_configs[IO_PORT_CNT * IO_PIN_CNT_PER_PORT] = {
 #if defined(ROBOTIC_ARM)
     // Application Pins
-    [IO_TEST_LED] = { IO_SELECT_OUTPUT, IO_ALT_FUNCTION_0, IO_RESISTOR_DISABLED,
+    [IO_TEST_LED] = { true, IO_SELECT_OUTPUT, IO_ALT_FUNCTION_0, IO_RESISTOR_DISABLED,
                       IO_OUT_LOW }, // PA5 OUTPUT
-    [IO_I2C_SCL] = { IO_SELECT_ALT, IO_ALT_FUNCTION_4, IO_PULL_UP_ENABLED,
+    [IO_I2C_SCL] = { true, IO_SELECT_ALT, IO_ALT_FUNCTION_4, IO_PULL_UP_ENABLED,
                      IO_OUT_HIGH }, // PB8 I2C1_SCL
-    [IO_I2C_SDA] = { IO_SELECT_ALT, IO_ALT_FUNCTION_4, IO_PULL_UP_ENABLED,
+    [IO_I2C_SDA] = { true, IO_SELECT_ALT, IO_ALT_FUNCTION_4, IO_PULL_UP_ENABLED,
                      IO_OUT_HIGH }, // PB9 I2C1_SDA
-    [IO_UART_RXD] = { IO_SELECT_ALT, IO_ALT_FUNCTION_7, IO_RESISTOR_DISABLED,
+    [IO_UART_RXD] = { true, IO_SELECT_ALT, IO_ALT_FUNCTION_7, IO_RESISTOR_DISABLED,
                       IO_OUT_LOW }, // PA10 USART1_RX
-    [IO_UART_TXD] = { IO_SELECT_ALT, IO_ALT_FUNCTION_7, IO_RESISTOR_DISABLED,
+    [IO_UART_TXD] = { true, IO_SELECT_ALT, IO_ALT_FUNCTION_7, IO_RESISTOR_DISABLED,
                       IO_OUT_LOW }, // PA9 USART1_TX
-    [IO_ANALOG_MUX_S0] = { IO_SELECT_OUTPUT, IO_ALT_FUNCTION_0, IO_RESISTOR_DISABLED,
+    [IO_ANALOG_MUX_S0] = { true, IO_SELECT_OUTPUT, IO_ALT_FUNCTION_0, IO_RESISTOR_DISABLED,
                            IO_OUT_LOW }, // PB4 Output etc
-    [IO_ANALOG_MUX_S1] = { IO_SELECT_OUTPUT, IO_ALT_FUNCTION_0, IO_RESISTOR_DISABLED,
+    [IO_ANALOG_MUX_S1] = { true, IO_SELECT_OUTPUT, IO_ALT_FUNCTION_0, IO_RESISTOR_DISABLED,
                            IO_OUT_LOW }, // PB5
-    [IO_ANALOG_MUX_S2] = { IO_SELECT_OUTPUT, IO_ALT_FUNCTION_0, IO_RESISTOR_DISABLED,
+    [IO_ANALOG_MUX_S2] = { true, IO_SELECT_OUTPUT, IO_ALT_FUNCTION_0, IO_RESISTOR_DISABLED,
                            IO_OUT_LOW }, // PB3
-    [IO_ANALOG_MUX_S3] = { IO_SELECT_OUTPUT, IO_ALT_FUNCTION_0, IO_RESISTOR_DISABLED,
+    [IO_ANALOG_MUX_S3] = { true, IO_SELECT_OUTPUT, IO_ALT_FUNCTION_0, IO_RESISTOR_DISABLED,
                            IO_OUT_LOW }, // PA15
-    [IO_ANALOG_MUX_ENABLE_1] = { IO_SELECT_OUTPUT, IO_ALT_FUNCTION_0, IO_RESISTOR_DISABLED,
+    [IO_ANALOG_MUX_ENABLE_1] = { true, IO_SELECT_OUTPUT, IO_ALT_FUNCTION_0, IO_RESISTOR_DISABLED,
                                  IO_OUT_LOW }, // PB12
-    [IO_ANALOG_MUX_ENABLE_2] = { IO_SELECT_OUTPUT, IO_ALT_FUNCTION_0, IO_RESISTOR_DISABLED,
+    [IO_ANALOG_MUX_ENABLE_2] = { true, IO_SELECT_OUTPUT, IO_ALT_FUNCTION_0, IO_RESISTOR_DISABLED,
                                  IO_OUT_LOW }, // PB13
-    [IO_ANALOG_MUX_COM_1] = { IO_SELECT_INPUT, IO_ALT_FUNCTION_0, IO_PULL_UP_ENABLED,
+    [IO_ANALOG_MUX_COM_1] = { true, IO_SELECT_INPUT, IO_ALT_FUNCTION_0, IO_PULL_UP_ENABLED,
                               IO_OUT_LOW }, // PA0
-    [IO_ANALOG_MUX_COM_2] = { IO_SELECT_INPUT, IO_ALT_FUNCTION_0, IO_PULL_UP_ENABLED,
+    [IO_ANALOG_MUX_COM_2] = { true, IO_SELECT_INPUT, IO_ALT_FUNCTION_0, IO_PULL_UP_ENABLED,
                               IO_OUT_LOW }, // PA1
-    [IO_PWM_DISTAL_INTERPHALANGEAL_JOINT] = { IO_SELECT_ALT, IO_ALT_FUNCTION_2,
+    [IO_PWM_DISTAL_INTERPHALANGEAL_JOINT] = { true, IO_SELECT_ALT, IO_ALT_FUNCTION_2,
                                               IO_RESISTOR_DISABLED, IO_OUT_LOW }, // PA6 TIM?
-    [IO_PWM_PROXIMAL_INTERPHALANGEAL_JOINT] = { IO_SELECT_ALT, IO_ALT_FUNCTION_2,
+    [IO_PWM_PROXIMAL_INTERPHALANGEAL_JOINT] = { true, IO_SELECT_ALT, IO_ALT_FUNCTION_2,
                                                 IO_RESISTOR_DISABLED, IO_OUT_LOW }, // PA7
-    [IO_PWM_METACARPOPHALANGEAL_JOINT_1] = { IO_SELECT_ALT, IO_ALT_FUNCTION_2, IO_RESISTOR_DISABLED,
-                                             IO_OUT_LOW }, // PC6?
-    [IO_PWM_METACARPOPHALANGEAL_JOINT_2] = { IO_SELECT_ALT, IO_ALT_FUNCTION_1, IO_RESISTOR_DISABLED,
-                                             IO_OUT_LOW }, // PB10
+    [IO_PWM_METACARPOPHALANGEAL_JOINT_1] = { true, IO_SELECT_ALT, IO_ALT_FUNCTION_2,
+                                             IO_RESISTOR_DISABLED, IO_OUT_LOW }, // PC6?
+    [IO_PWM_METACARPOPHALANGEAL_JOINT_2] = { true, IO_SELECT_ALT, IO_ALT_FUNCTION_1,
+                                             IO_RESISTOR_DISABLED, IO_OUT_LOW }, // PB10
 
     // Board-specific
-    [IO_PA2] = { IO_SELECT_ALT, IO_ALT_FUNCTION_7, IO_RESISTOR_DISABLED, IO_OUT_LOW }, // USART2_TX
-    [IO_PA3] = { IO_SELECT_ALT, IO_ALT_FUNCTION_7, IO_RESISTOR_DISABLED, IO_OUT_LOW }, // USART2_RX
-    [IO_PC13] = { IO_SELECT_INPUT, IO_ALT_FUNCTION_0, IO_PULL_UP_ENABLED,
+    [IO_PA2] = { true, IO_SELECT_ALT, IO_ALT_FUNCTION_7, IO_RESISTOR_DISABLED,
+                 IO_OUT_LOW }, // USART2_TX
+    [IO_PA3] = { true, IO_SELECT_ALT, IO_ALT_FUNCTION_7, IO_RESISTOR_DISABLED,
+                 IO_OUT_LOW }, // USART2_RX
+    [IO_PC13] = { true, IO_SELECT_INPUT, IO_ALT_FUNCTION_0, IO_PULL_UP_ENABLED,
                   IO_OUT_LOW }, // User Button
-    [IO_PC14] = { IO_SELECT_ANALOG, IO_ALT_FUNCTION_0, IO_RESISTOR_DISABLED,
+    [IO_PC14] = { true, IO_SELECT_ANALOG, IO_ALT_FUNCTION_0, IO_RESISTOR_DISABLED,
                   IO_OUT_LOW }, // LSE Crystal
-    [IO_PC15] = { IO_SELECT_ANALOG, IO_ALT_FUNCTION_0, IO_RESISTOR_DISABLED,
+    [IO_PC15] = { true, IO_SELECT_ANALOG, IO_ALT_FUNCTION_0, IO_RESISTOR_DISABLED,
                   IO_OUT_LOW }, // LSE Crystal
 #elif defined(ARM_SLEEVE)
     // Application Pins
-    [IO_I2C_SCL] = { IO_SELECT_ALT, IO_ALT_FUNCTION_4, IO_PULL_UP_ENABLED,
+    [IO_I2C_SCL] = { true, IO_SELECT_ALT, IO_ALT_FUNCTION_4, IO_PULL_UP_ENABLED,
                      IO_OUT_HIGH }, // PB8, I2C1_SCL
-    [IO_I2C_SDA] = { IO_SELECT_ALT, IO_ALT_FUNCTION_4, IO_PULL_UP_ENABLED,
+    [IO_I2C_SDA] = { true, IO_SELECT_ALT, IO_ALT_FUNCTION_4, IO_PULL_UP_ENABLED,
                      IO_OUT_HIGH }, // PB9, I2C1_SDA
-    [IO_UART_TXD] = { IO_SELECT_ALT, IO_ALT_FUNCTION_7, IO_RESISTOR_DISABLED,
+    [IO_UART_TXD] = { true, IO_SELECT_ALT, IO_ALT_FUNCTION_7, IO_RESISTOR_DISABLED,
                       IO_OUT_LOW }, // PA9, USART1_TX
-    [IO_UART_RXD] = { IO_SELECT_ALT, IO_ALT_FUNCTION_7, IO_RESISTOR_DISABLED,
+    [IO_UART_RXD] = { true, IO_SELECT_ALT, IO_ALT_FUNCTION_7, IO_RESISTOR_DISABLED,
                       IO_OUT_LOW }, // PA10, USART1_RX
-    [IO_TEST_LED] = { IO_SELECT_OUTPUT, IO_ALT_FUNCTION_0, IO_RESISTOR_DISABLED,
+    [IO_TEST_LED] = { true, IO_SELECT_OUTPUT, IO_ALT_FUNCTION_0, IO_RESISTOR_DISABLED,
                       IO_OUT_LOW }, // PC13, User LED
 #endif
 };
 
 // Default config for all *other* pins
-const struct io_config io_default_unused = { IO_SELECT_ANALOG, IO_ALT_FUNCTION_0,
+const struct io_config io_default_unused = { false, IO_SELECT_ANALOG, IO_ALT_FUNCTION_0,
                                              IO_RESISTOR_DISABLED, IO_OUT_LOW };
 
 typedef enum {
@@ -128,8 +132,8 @@ typedef enum {
 
 /* STM32 provides a register that tells you what model their microcontroller is.
  * By accessing it, we can get the ID and the hardware type. */
-#define STM32F411_DEVICE_ID 0x1B1
-#define STM32F446_DEVICE_ID 0x1C9
+#define STM32F411_DEVICE_ID 0x431
+#define STM32F446_DEVICE_ID 0x421
 
 static hw_type_e io_detect_hw_type(void)
 {
@@ -161,17 +165,42 @@ void io_init(void)
 #endif
     for (int io = 0; io < IO_PIN_MAX; io++) {
         const struct io_config *cfg =
-            (io_initial_configs[io].select != 0) ? &io_initial_configs[io] : &io_default_unused;
-        io_configure(io, cfg);
+            (io_initial_configs[io].used != false) ? &io_initial_configs[io] : &io_default_unused;
+        if (io != IO_PA13 && io != IO_PA14) {
+            io_configure(io, cfg);
+        }
     }
 }
 
 void io_configure(io_e io, const struct io_config *config)
 {
+    // Forbid configuring PA13 or PA14 (SWD/JTAG debug pins)
+    ASSERT(io != (io_e)IO_PA13 && io != (io_e)IO_PA14);
+
     io_enable_clock(io);
     io_set_select(io, config->select, config->io_alt_function);
     io_set_resistor(io, config->resistor);
     io_set_out(io, config->out);
+}
+
+void io_get_current_config(io_e io, struct io_config *current_config)
+{
+    const uint8_t port = io_port(io); // 0
+    const uint8_t pin = io_pin_idx(io); // 5
+    GPIO_TypeDef *gpio = gpio_ports[port]; // gpioa
+    uint8_t afr_n = pin / 8; // 0 or 1
+    uint8_t afr_shift = (pin % 8) * 4; // number of shift indices
+
+    current_config->select = (io_select_e)(gpio->MODER >> (pin * 2)) & (0x3);
+    current_config->io_alt_function = (io_alt_function_e)(gpio->AFR[afr_n] >> (afr_shift)) & (0xFu);
+    current_config->resistor = (io_resistor_e)(gpio->PUPDR >> (pin * 2)) & (0x3);
+    current_config->out = (io_out_e)(gpio->ODR >> pin) & (0x1);
+}
+
+bool io_config_compare(const struct io_config *cfg1, const struct io_config *cfg2)
+{
+    return (cfg1->select == cfg2->select) && (cfg1->io_alt_function == cfg2->io_alt_function)
+        && (cfg1->resistor == cfg2->resistor) && (cfg1->out == cfg2->out);
 }
 
 void io_set_select(io_e io, io_select_e select, io_alt_function_e alt_function)

--- a/src/drivers/io.h
+++ b/src/drivers/io.h
@@ -139,6 +139,7 @@ typedef enum {
 
 struct io_config
 {
+    bool used;
     io_select_e select;
     io_alt_function_e io_alt_function;
     io_resistor_e resistor;
@@ -148,6 +149,8 @@ struct io_config
 // TODO: functions
 void io_init(void);
 void io_configure(io_e io, const struct io_config *config);
+void io_get_current_config(io_e io, struct io_config *current_config);
+bool io_config_compare(const struct io_config *cfg1, const struct io_config *cfg2);
 void io_set_select(io_e io, io_select_e select, io_alt_function_e alt_function);
 void io_set_resistor(io_e io, io_resistor_e resistor); // only applicable if pin is set to input
 void io_set_out(io_e io, io_out_e out);

--- a/src/drivers/led.c
+++ b/src/drivers/led.c
@@ -1,15 +1,35 @@
 #include <stm32f4xx.h>
-// #include "../include/stm32f446xx.h"
 #include "led.h"
-// A5 for nucleo, C13 for black pill
-#define LED_PIN 13
+#include "io.h"
+#include "../common/defines.h"
+#include <stdbool.h>
+#include "../common/assert_handler.h"
 
+static const struct io_config led_config = {
+    .used = true,
+    .select = IO_SELECT_OUTPUT,
+    .io_alt_function = IO_ALT_FUNCTION_0,
+    .resistor = IO_RESISTOR_DISABLED,
+    .out = IO_OUT_LOW,
+};
+
+static bool initialized = false;
 void led_init(void)
 {
-    GPIOC->MODER |= (1U << (LED_PIN * 2)); // Set PB0 to output mode (01)
+    ASSERT(!initialized);
+    struct io_config current_config;
+    io_get_current_config(IO_TEST_LED, &current_config);
+    ASSERT(io_config_compare(&led_config, &current_config));
+    initialized = true;
 }
 
-void led_toggle(void)
+void led_set(led_e led, led_state_e state)
 {
-    GPIOC->ODR ^= (1U << LED_PIN); // Toggle PB0
+    ASSERT(initialized);
+    const io_out_e out = (state == LED_STATE_ON) ? IO_OUT_HIGH : IO_OUT_LOW;
+    switch (led) {
+    case LED_TEST:
+        io_set_out(IO_TEST_LED, out);
+        break;
+    }
 }

--- a/src/drivers/led.h
+++ b/src/drivers/led.h
@@ -1,2 +1,17 @@
+#ifndef LED_H
+
+// Simple driver for controlling GPIOs with LEDs connected to them.
+
+typedef enum {
+    LED_TEST,
+} led_e;
+
+typedef enum {
+    LED_STATE_OFF,
+    LED_STATE_ON,
+} led_state_e;
+
 void led_init(void);
-void led_toggle(void);
+void led_set(led_e led, led_state_e state);
+
+#endif // LED_H

--- a/src/main.c
+++ b/src/main.c
@@ -3,31 +3,32 @@
 #include "drivers/led.h"
 #include "drivers/io.h"
 #include "drivers/mcu_init.h"
-
-#define LED_PIN 13
+#include "common/assert_handler.h"
+#include "common/defines.h"
 
 static void test_setup(void)
 {
     mcu_init();
 }
 
+// static void test_assert(void)
+// {
+//     test_setup();
+//     ASSERT(0);
+// }
+
 static void test_blink_led(void)
 {
     test_setup();
-
-    const struct io_config led_config = {
-        .select = IO_SELECT_OUTPUT,
-        .io_alt_function = IO_ALT_FUNCTION_0,
-        .resistor = IO_RESISTOR_DISABLED,
-    };
-
-    io_configure(IO_TEST_LED, &led_config);
-    io_out_e out = IO_OUT_LOW;
+    io_init();
+    led_init();
+    led_init();
+    led_state_e led_state = LED_STATE_OFF;
 
     while (1) {
-        out = (out == IO_OUT_LOW) ? IO_OUT_HIGH : IO_OUT_LOW;
-        io_set_out(IO_TEST_LED, out);
-        for (volatile int i = 0; i < 500000; i++) { }
+        led_state = (led_state == LED_STATE_OFF) ? LED_STATE_ON : LED_STATE_OFF;
+        led_set(LED_TEST, led_state);
+        BUSY_WAIT_ms(1000);
     }
 }
 
@@ -129,21 +130,5 @@ int main(void)
     // test_nucleo_io_pins_input();
     // test_nucleo_io_pins_output();
     test_blink_led();
+    // test_assert();
 }
-
-// int main(void)
-// {
-//     // Enable the GPIOB clock
-//     RCC->AHB1ENR |= RCC_AHB1ENR_GPIOCEN; // Enable clock for GPIO port B
-//     // Set pin PB0 as output
-//     GPIOC->MODER &= ~(3U << (LED_PIN * 2)); // Clear mode bits for PB0
-//     led_init();
-//     // GPIOA->MODER |= (1U << (LED_PIN * 2));
-
-//     while (1) {
-//         led_toggle();
-//         // GPIOA->ODR ^= (1U << LED_PIN);
-//         for (volatile int i = 0; i < 100000; i++)
-//             ; // Busy wait
-//     }
-// }


### PR DESCRIPTION
- doesn't use the BREAKPOINT feature by default since in STM32, under debugger mode, it stops the blinking completely. The blinking is important in visually recognizing a mistake in the code, so I'd rather keep that.
fix(io):
- fix issues regarding different hardware versions.